### PR TITLE
Align with API change introduced by 51b807c (Rename MonadShiftMap to ShiftMap)

### DIFF
--- a/concur-react/src/Concur/React/Widgets.hs
+++ b/concur-react/src/Concur/React/Widgets.hs
@@ -16,7 +16,7 @@ import           Control.Concurrent.STM     (STM, atomically)
 import           Unsafe.Coerce              (unsafeCoerce)
 
 import           Concur.React.DOM
-import           Control.MonadShiftMap
+import           Control.ShiftMap
 import           Control.MonadSTM
 
 -- TODO: Since we can't have a top level text in React. We currently always wrap it in span.
@@ -24,15 +24,15 @@ text :: String -> Widget HTML a
 text txt = display [vtext $ JSS.pack txt]
 
 -- Like el_ but accepts a React Component reference instead of a tagname
-elComp :: (MonadShiftMap (Widget HTML) m) => JSVal -> [VAttr] -> m a -> m a
+elComp :: (ShiftMap (Widget HTML) m) => JSVal -> [VAttr] -> m a -> m a
 elComp e attrs = shiftMap (wrapView (vnode e attrs))
 
 -- Generic Element wrapper (single child widget)
-el_ :: (MonadShiftMap (Widget HTML) m) => JSString -> [VAttr] -> m a -> m a
+el_ :: (ShiftMap (Widget HTML) m) => JSString -> [VAttr] -> m a -> m a
 el_ = elComp . unsafeCoerce
 
 -- Generic Element wrapper
-el :: (MonadShiftMap (Widget HTML) m, MultiAlternative m) => JSString -> [VAttr] -> [m a] -> m a
+el :: (ShiftMap (Widget HTML) m, MultiAlternative m) => JSString -> [VAttr] -> [m a] -> m a
 el e attrs = el_ e attrs . orr
 
 -- Create a dom leaf node
@@ -48,7 +48,7 @@ mkEventHandlerAttr evtName = do
   return (attr, await n)
 
 -- Handle arbitrary events on an element.
-elEvent :: (MonadShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadSTM m)
+elEvent :: (ShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadSTM m)
         => JSString
         -> (JSVal -> a)
         -> JSString
@@ -58,7 +58,7 @@ elEvent :: (MonadShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadSTM
 elEvent evtName xtract tag attrs child = elEventComp evtName xtract (unsafeCoerce tag) attrs child
 
 -- Like elEvent, but works for arbitrary react components
-elEventComp :: (MonadShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadSTM m)
+elEventComp :: (ShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadSTM m)
         => JSString
         -> (JSVal -> a)
         -> JSVal
@@ -70,7 +70,7 @@ elEventComp evtName xtract e attrs child = do
   orr [fmap xtract $ liftSTM w, elComp e (a:attrs) child]
 
 -- Similar to elEventComp, but specialised to the case where there are no child events.
-elEventComp' :: (MonadShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadSTM m)
+elEventComp' :: (ShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadSTM m)
          => JSString
          -> JSVal
          -> [VAttr]
@@ -79,7 +79,7 @@ elEventComp' :: (MonadShiftMap (Widget HTML) m, MultiAlternative m, Monad m, Mon
 elEventComp' evtName comp attrs child = elEventComp evtName id comp attrs (fmap absurd child)
 
 -- Similar to elEvent, but specialised to the case where there are no child events.
-elEvent' :: (MonadShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadSTM m)
+elEvent' :: (ShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadSTM m)
          => JSString
          -> JSString
          -> [VAttr]
@@ -88,11 +88,11 @@ elEvent' :: (MonadShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadST
 elEvent' evtName tag attrs child = elEvent evtName id tag attrs (fmap absurd child)
 
 -- A clickable button widget. Returns either the button click, or the child event.
-button :: (MonadShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadSTM m) => [VAttr] -> m () -> m ()
+button :: (ShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadSTM m) => [VAttr] -> m () -> m ()
 button attrs w = elEvent "onClick" (const ()) "button" attrs w
 
 -- A clickable button widget, specialised to the case when there are no child events.
-button' :: (MonadShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadSTM m) => [VAttr] -> m Void -> m ()
+button' :: (ShiftMap (Widget HTML) m, MultiAlternative m, Monad m, MonadSTM m) => [VAttr] -> m Void -> m ()
 button' attrs w = void $ elEvent' "onClick" "button" attrs w
 
 -- Text input. Returns the contents on keypress enter.


### PR DESCRIPTION
Hello there, thank you for Concur, I just started playing with it and it seems very promising!

Without this change, compiling concur-react from current master (54425ed) fails with this error:

```
ste@ennere ~/opt/demaledetti/concur/concur-react $ stack build --stack-yaml stack-ghcjs.yaml
natural-transformation-0.4: configure
natural-transformation-0.4: build
natural-transformation-0.4: copy/register
concur-core-0.1.0.0: configure (lib)
concur-core-0.1.0.0: build (lib)
concur-core-0.1.0.0: copy/register
Building all executables for `concur-react' once. After a successful build of all of them, only specified executables will be rebuilt.
concur-react-0.1.0.0: configure (lib + exe)
concur-react-0.1.0.0: build (lib + exe)
Completed 3 action(s).
Log files have been written to: /home/ste/opt/demaledetti/concur/concur-react/.stack-work/logs/

--  While building custom Setup.hs for package concur-react-0.1.0.0 using:
      /home/ste/.stack/setup-exe-cache/x86_64-linux/Cabal-simple_mPHDZzAJ_1.24.2.0_ghcjs-0.2.1.9007019_ghc-8.0.1 --builddir=.stack-work/dist/x86_64-linux/Cabal-1.24.2.0_ghcjs build lib:concur-react exe:concur-react-calculator exe:concur-react-hilo exe:concur-react-menu exe:concur-react-multi-entry --ghcjs-options " -d
dump-hi -ddump-to-file"
    Process exited with code: ExitFailure 1
    Logs have been written to: /home/ste/opt/demaledetti/concur/concur-react/.stack-work/logs/concur-react-0.1.0.0.log

    Configuring concur-react-0.1.0.0...
    Preprocessing library concur-react-0.1.0.0...
    [1 of 6] Compiling Paths_concur_react ( .stack-work/dist/x86_64-linux/Cabal-1.24.2.0_ghcjs/build/autogen/Paths_concur_react.hs, .stack-work/dist/x86_64-linux/Cabal-1.24.2.0_ghcjs/build/Paths_concur_react.js_o )
    [2 of 6] Compiling Concur.Internal.ReactFFI ( src-ghcjs/Concur/Internal/ReactFFI.hs, .stack-work/dist/x86_64-linux/Cabal-1.24.2.0_ghcjs/build/Concur/Internal/ReactFFI.js_o )
    [3 of 6] Compiling Concur.React.DOM ( src/Concur/React/DOM.hs, .stack-work/dist/x86_64-linux/Cabal-1.24.2.0_ghcjs/build/Concur/React/DOM.js_o )
    [4 of 6] Compiling Concur.React.Widgets ( src/Concur/React/Widgets.hs, .stack-work/dist/x86_64-linux/Cabal-1.24.2.0_ghcjs/build/Concur/React/Widgets.js_o )

    /home/ste/opt/demaledetti/concur/concur-react/src/Concur/React/Widgets.hs:19:1-38: error:
        Failed to load interface for ‘Control.MonadShiftMap’
        Perhaps you meant Control.ShiftMap (from concur-core-0.1.0.0)
        Use -v to see a list of the files searched for.
```

With this change it succeeds:

```
ste@ennere ~/opt/demaledetti/concur/concur-react $ stack build --stack-yaml stack-ghcjs.yaml
Building all executables for `concur-react' once. After a successful build of all of them, only specified executables will be rebuilt.
concur-react-0.1.0.0: configure (lib + exe)
concur-react-0.1.0.0: build (lib + exe)
concur-react-0.1.0.0: copy/register
Log files have been written to: /home/ste/opt/demaledetti/concur/concur-react/.stack-work/logs/
```
